### PR TITLE
Fix DialogPortal typing

### DIFF
--- a/components/ui/dialog/dialog.tsx
+++ b/components/ui/dialog/dialog.tsx
@@ -9,11 +9,15 @@ const Root = DialogPrimitive.Root
 
 const Trigger = DialogPrimitive.Trigger
 
-const DialogPortal = ({
-  className,
-  ...props
-}: DialogPrimitive.DialogPortalProps) => (
-  <DialogPrimitive.Portal className={cn(className)} {...props} />
+interface DialogPortalProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Portal> {
+  className?: string
+}
+
+const DialogPortal = ({ className, children, ...props }: DialogPortalProps) => (
+  <DialogPrimitive.Portal {...props}>
+    <div className={cn(className)}>{children}</div>
+  </DialogPrimitive.Portal>
 )
 DialogPortal.displayName = DialogPrimitive.Portal.displayName
 


### PR DESCRIPTION
## Summary
- add wrapper for `DialogPortal` so className can be applied without type errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859279fa454832da5edfbad7ffb6376